### PR TITLE
Unstash error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * A Config class instance is passed as config keyword argument to the
   **precommit** plugin function. It can be used to receive plugin specific
   settings [#7](https://github.com/greenbone/autohooks/pull/7)
+* Show a warning if changes created by formatting plugins conflict with stashed
+  unstaged changes [#13](https://github.com/greenbone/autohooks/pull/13)
 
 ### Removed
 

--- a/autohooks/utils.py
+++ b/autohooks/utils.py
@@ -21,6 +21,14 @@ import subprocess
 from pathlib import Path
 
 
+class GitError(subprocess.CalledProcessError):
+    def __str__(self):
+        return "Git command '%s' returned non-zero exit status %d" % (
+            self.cmd,
+            self.returncode,
+        )
+
+
 def exec_git(*args, ignore_errors=False):
     try:
         cmd_args = ['git']
@@ -30,7 +38,7 @@ def exec_git(*args, ignore_errors=False):
     except subprocess.CalledProcessError as e:
         if ignore_errors:
             return ''
-        raise e
+        raise GitError(e.returncode, e.cmd, e.output, e.stderr)
 
 
 def get_git_directory_path():


### PR DESCRIPTION
autohooks plugins stash unrelated changes before applying formatting. When un-stashing the unrelated changes these changes my conflict with the changes made by the formatter plugins. This change shows a message in this case and removes the created *.rej* files

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
