### PR TITLE
Allow for a simplified access to a config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved and colorized terminal output [#14](https://github.com/greenbone/autohooks/pull/14)
 * Show a warning if changes created by formatting plugins conflict with stashed
   unstaged changes [#13](https://github.com/greenbone/autohooks/pull/13)
+* Allow to access config sections via passing an argument list to **config.get**
+  e.g. config.get('tools', 'autohooks', 'plugins', 'foo')
+  [#15](https://github.com/greenbone/autohooks/pull/15)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -178,10 +178,7 @@ def precommit(**kwargs):
     config = kwargs.get('config')
     default_value = 1
     setting = config
-      .get('tool')
-      .get('autohooks')
-      .get('plugins')
-      .get('foo')
+      .get('tool', 'autohooks', 'plugins', 'foo')
       .get_value('bar', default_value)
     return 0
 ```
@@ -219,7 +216,7 @@ def get_include(config)
     if not config:
         return DEFAULT_INCLUDE
 
-    config = config.get('tool').get('autohooks').get('plugins').get('foo')
+    config = config.get('tool', 'autohooks', 'plugins', 'foo')
     return config.get_value('include', DEFAULT_INCUDE)
 
 
@@ -277,7 +274,7 @@ def get_include(config)
     if not config:
         return DEFAULT_INCLUDE
 
-    config = config.get('tool').get('autohooks').get('plugins').get('bar')
+    config = config.get('tool', 'autohooks', 'plugins', 'bar')
     return config.get_value('include', DEFAULT_INCUDE)
 
 

--- a/autohooks/config.py
+++ b/autohooks/config.py
@@ -26,8 +26,13 @@ class Config:
     def __init__(self, config_dict=None):
         self._config_dict = config_dict or {}
 
-    def get(self, key):
-        return Config(self._config_dict.get(key, {}))
+    def get(self, *keys):
+        config_dict = self._config_dict
+
+        for key in keys:
+            config_dict = config_dict.get(key, {})
+
+        return Config(config_dict)
 
     def get_value(self, key, default=None):
         return self._config_dict.get(key, default)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -157,3 +157,16 @@ class ConfigTestCase(unittest.TestCase):
         self.assertEqual(foo_config.get_value('lorem'), 'ipsum')
         self.assertEqual(foo_config.get_value('lorem', 'dolor'), 'ipsum')
         self.assertEqual(foo_config.get_value('bar', 'dolor'), 'dolor')
+
+    def test_config_point_syntax(self):
+        config_dict = {
+            'tool': {'autohooks': {'plugins': {'bar': {'lorem': 'ipsum'}}}}
+        }
+
+        config = Config(config_dict)
+
+        self.assertFalse(config.is_empty())
+
+        bar_config = config.get('tool', 'autohooks', 'plugins', 'bar')
+        self.assertFalse(bar_config.is_empty())
+        self.assertEqual(bar_config.get_value('lorem'), 'ipsum')


### PR DESCRIPTION
Instead of config.get('foo').get('bar') allow config.get('foo', 'bar')
too.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [x] Documentation
