### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,28 @@ To install autohooks as a development dependency run
 pipenv install --dev autohooks
 ```
 
-Alternatively autohooks can be installed directly from GitHub
+or add
+
+```
+autohooks = {git = "https://github.com/greenbone/autohooks"}
+```
+
+to your `Pipfile`.
+
+Alternatively autohooks can be installed directly from GitHub by running
 
 ```sh
-pipenv install --dev -e git+https://github.com/greenbone/autohooks#egg=autohooks
+pipenv install --dev git+https://github.com/greenbone/autohooks#egg=autohooks
 ```
+
+or adding
+
+```
+autohooks = {git = "https://github.com/greenbone/autohooks"}
+```
+
+to your `Pipfile`.
+
 
 ### Activating the git hooks
 


### PR DESCRIPTION
Trying to install `autohooks` editable yields
```
ERROR: Error installing \'autohooks from git+https://github.com/greenbone/autohooks@1002db08b1aefdde909117e2e0e2bad1da2fafc8#egg=autohooks\': editable mode is not supported for pyproject.toml-style projects. pip is processing this project as pyproject.toml-style because it has a pyproject.toml file. Since the project has a setup.py and the pyproject.toml has no "build-backend" key for the "build_system" value, you may pass --no-use-pep517 to opt out of pyproject.toml-style processing. See PEP 517 for details on pyproject.toml-style projects.
```

Installing non-editable works.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
