### PR TITLE
Allow to run autohooks check if no pre-commit file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* Windows Support, by exchanging the unmaintained `blessing` module through [`colorful`](https://github.com/timofurrer/colorful) [#45](https://github.com/greenbone/autohooks/pull/45)
+* Windows Support, by exchanging the unmaintained `blessing` module through
+  [`colorful`](https://github.com/timofurrer/colorful)
+  [#45](https://github.com/greenbone/autohooks/pull/45)
+* Fixed running `autohooks check` if no `.git/hooks/pre-commit` file exists
+  [#49](https://github.com/greenbone/autohooks/pull/49)
 
 ### Removed
 

--- a/autohooks/cli/check.py
+++ b/autohooks/cli/check.py
@@ -39,17 +39,15 @@ from autohooks.terminal import Terminal
 
 def check_hooks(term: Terminal) -> None:
     pre_commit_hook = PreCommitHook()
-    hook_mode = pre_commit_hook.read_mode()
-
-    check_pre_commit_hook(term, pre_commit_hook, hook_mode)
+    check_pre_commit_hook(term, pre_commit_hook)
 
     pyproject_toml = get_pyproject_toml_path()
 
-    check_config(term, pyproject_toml, pre_commit_hook, hook_mode)
+    check_config(term, pyproject_toml, pre_commit_hook)
 
 
 def check_pre_commit_hook(
-    term: Terminal, pre_commit_hook: PreCommitHook, hook_mode: Mode,
+    term: Terminal, pre_commit_hook: PreCommitHook
 ) -> None:
     if pre_commit_hook.exists():
         if pre_commit_hook.is_autohooks_pre_commit_hook():
@@ -89,10 +87,7 @@ def check_pre_commit_hook(
 
 
 def check_config(
-    term: Terminal,
-    pyproject_toml: Path,
-    pre_commit_hook: PreCommitHook,
-    hook_mode: Mode,
+    term: Terminal, pyproject_toml: Path, pre_commit_hook: PreCommitHook,
 ) -> None:
     if not pyproject_toml.exists():
         term.error(
@@ -106,8 +101,10 @@ def check_config(
                 'autohooks is not enabled in your {} file. Please add '
                 'a "{}" section.'.format(str(pyproject_toml), AUTOHOOKS_SECTION)
             )
-        else:
+        elif pre_commit_hook.exists():
             config_mode = config.get_mode()
+            hook_mode = pre_commit_hook.read_mode()
+
             if config_mode == Mode.UNDEFINED:
                 term.warning(
                     'autohooks mode is not defined in {}.'.format(


### PR DESCRIPTION
If the .git/hooks/pre-commit file doesn't exist running autohooks check
should not fail and instead display that the file is missing and
autohooks activate should be run.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
