### PR TITLE
Improve Terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added tools for version handling in autohooks [#51](https://github.com/greenbone/autohooks/pull/51)
+* Added static `get_width` method to Terminal class [#53](https://github.com/greenbone/autohooks/pull/53)
 
 ### Changed
 

--- a/autohooks/terminal.py
+++ b/autohooks/terminal.py
@@ -28,23 +28,27 @@ TERMINAL_SIZE_FALLBACK = (80, 24)  # use a small standard size as fallback
 
 class Terminal:
     def __init__(self):
-        self._width = None
         self._indent = 0
 
-    def _check_size(self):
-        self._width, _ = shutil.get_terminal_size(TERMINAL_SIZE_FALLBACK)
+    @staticmethod
+    def get_width() -> int:
+        """
+        Get the width of the terminal window
+        """
+        width, _ = shutil.get_terminal_size(TERMINAL_SIZE_FALLBACK)
+        return width
 
     def _print_end(self, message: str, status: str, color: Callable) -> None:
-        extra = 4  # '[ ', ' ]'
-        # python is adding a ' ' between strings if used
-        # in print('foo', 'bar', 'baz') is printed to "foo bar baz"
-        self._check_size()
+        extra = 4  # '[ ' and ' ]'
+
         if self._indent > 0:
             message = ' ' * self._indent + message
-        if self._width > 0:
-            message += ' ' * (
-                int(self._width) - len(message) - extra - len(status)
-            )
+
+        width = self.get_width()
+
+        if width > 0:
+            message += ' ' * (int(width) - len(message) - extra - len(status))
+
         print(
             message + '[', color(status), ']',
         )

--- a/autohooks/terminal.py
+++ b/autohooks/terminal.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
+import shutil
 
 from contextlib import contextmanager
 
@@ -30,7 +30,7 @@ class Terminal:
         self._indent = 0
 
     def _check_size(self):
-        self._width, _ = os.get_terminal_size()
+        self._width, _ = shutil.get_terminal_size()
 
     def _print_end(self, message: str, status: str, color: Callable) -> None:
         extra = 4  # '[ ', ' ]'

--- a/autohooks/terminal.py
+++ b/autohooks/terminal.py
@@ -23,6 +23,8 @@ from typing import Callable, Generator
 
 import colorful as cf
 
+TERMINAL_SIZE_FALLBACK = (80, 24)  # use a small standard size as fallback
+
 
 class Terminal:
     def __init__(self):
@@ -30,7 +32,7 @@ class Terminal:
         self._indent = 0
 
     def _check_size(self):
-        self._width, _ = shutil.get_terminal_size()
+        self._width, _ = shutil.get_terminal_size(TERMINAL_SIZE_FALLBACK)
 
     def _print_end(self, message: str, status: str, color: Callable) -> None:
         extra = 4  # '[ ', ' ]'

--- a/poetry.lock
+++ b/poetry.lock
@@ -197,6 +197,17 @@ python-versions = "*"
 version = "2020.2.20"
 
 [[package]]
+category = "dev"
+description = "a python refactoring library..."
+name = "rope"
+optional = false
+python-versions = "*"
+version = "0.16.0"
+
+[package.extras]
+dev = ["pytest"]
+
+[[package]]
 category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
@@ -239,7 +250,7 @@ python-versions = "*"
 version = "1.11.2"
 
 [metadata]
-content-hash = "0f3b92f34292345ba8bcfbf5f0c1a272375a5f521c21a090d4b32bfb2c2e248e"
+content-hash = "3c62c4400ea112cc281f37a989bf017206df84a1afe08774b4efee7d8f7c0853"
 python-versions = "^3.5"
 
 [metadata.files]
@@ -348,6 +359,11 @@ regex = [
     {file = "regex-2020.2.20-cp38-cp38-win32.whl", hash = "sha256:200539b5124bc4721247a823a47d116a7a23e62cc6695744e3eb5454a8888e6d"},
     {file = "regex-2020.2.20-cp38-cp38-win_amd64.whl", hash = "sha256:7f78f963e62a61e294adb6ff5db901b629ef78cb2a1cfce3cf4eeba80c1c67aa"},
     {file = "regex-2020.2.20.tar.gz", hash = "sha256:9e9624440d754733eddbcd4614378c18713d2d9d0dc647cf9c72f64e39671be5"},
+]
+rope = [
+    {file = "rope-0.16.0-py2-none-any.whl", hash = "sha256:ae1fa2fd56f64f4cc9be46493ce54bed0dd12dee03980c61a4393d89d84029ad"},
+    {file = "rope-0.16.0-py3-none-any.whl", hash = "sha256:52423a7eebb5306a6d63bdc91a7c657db51ac9babfb8341c9a1440831ecf3203"},
+    {file = "rope-0.16.0.tar.gz", hash = "sha256:d2830142c2e046f5fc26a022fe680675b6f48f81c7fc1f03a950706e746e9dfe"},
 ]
 six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pylint = "^2.4.4"
 autohooks-plugin-pylint = "^1.2.0"
 autohooks-plugin-black = {version = "^1.2.0", python = "^3.6"}
 black = {version = "19.10b0", python = "^3.6"}
+rope = "^0.16.0"
 
 [tool.poetry.scripts]
 autohooks = "autohooks.cli:main"

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -18,11 +18,12 @@
 # pylint: disable=invalid-name, protected-access
 
 import unittest
-import os
+
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import colorful as cf
+
 from autohooks.terminal import Terminal
 
 
@@ -37,212 +38,156 @@ class TerminalTestCase(unittest.TestCase):
         self.reset = cf.black.style[
             1
         ]  # every colors second value is the reset value ...
+        self.term = Terminal()
+        self.term.get_width = MagicMock(return_value=80)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_error(self, mock_stdout):
-        term = Terminal()
+        msg = 'foo bar'
 
-        width, _ = os.get_terminal_size()
-        est_len = width + len(self.red) + len(self.reset) + 1
+        width = self.term.get_width()
+        expected_len = width + len(self.red) + len(self.reset) + 1
 
-        term.error('foo bar')
+        status = '[ {}error{} ]\n'.format(self.red, self.reset)
+        sep = ' ' * (expected_len - len(msg) - len(status))
+
+        expected_msg = msg + sep + status
+
+        self.term.error(msg)
 
         ret = mock_stdout.getvalue()
-        status = '[ {}error{} ]\n'.format(self.red, self.reset)
-        msg = 'foo bar'
-        sep = ' ' * (est_len - (len(msg) + len(status)))
 
-        reg = msg + sep + status
-
-        self.assertIsNotNone(term._width)
-        self.assertEqual(term._width, width)
-        if width is 0:
-            est_len = (
-                len(msg)
-                + len('[ error ]')
-                + len(self.yellow)
-                + len(self.reset)
-                + 1
-            )
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, reg)
+        self.assertEqual(len(ret), expected_len)
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_fail(self, mock_stdout):
-        term = Terminal()
+        width = self.term.get_width()
+        expected_len = width + len(self.red) + len(self.reset) + 1
 
-        width, _ = os.get_terminal_size()
-        est_len = width + len(self.red) + len(self.reset) + 1
-
-        term.fail('foo bar baz')
-
-        ret = mock_stdout.getvalue()
         status = '[ {}fail{} ]\n'.format(self.red, self.reset)
         msg = 'foo bar baz'
-        sep = ' ' * (est_len - (len(msg) + len(status)))
+        sep = ' ' * (expected_len - len(msg) - len(status))
 
-        reg = msg + sep + status
+        expected_msg = msg + sep + status
 
-        self.assertIsNotNone(term._width)
-        self.assertEqual(term._width, width)
-        if width is 0:
-            est_len = (
-                len(msg)
-                + len('[ fail ]')
-                + len(self.yellow)
-                + len(self.reset)
-                + 1
-            )
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, reg)
+        self.term.fail('foo bar baz')
+
+        ret = mock_stdout.getvalue()
+
+        self.assertEqual(len(ret), expected_len)
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_info(self, mock_stdout):
-        term = Terminal()
+        width = self.term.get_width()
+        expected_len = width + len(self.cyan) + len(self.reset) + 1
 
-        width, _ = os.get_terminal_size()
-        est_len = width + len(self.cyan) + len(self.reset) + 1
-
-        term.info('foo bar')
-
-        ret = mock_stdout.getvalue()
         status = '[ {}info{} ]\n'.format(self.cyan, self.reset)
         msg = 'foo bar'
-        sep = ' ' * (est_len - (len(msg) + len(status)))
+        sep = ' ' * (expected_len - len(msg) - len(status))
 
-        reg = msg + sep + status
+        expected_msg = msg + sep + status
 
-        self.assertIsNotNone(term._width)
-        self.assertEqual(term._width, width)
-        if width is 0:
-            est_len = (
-                len(msg)
-                + len('[ info ]')
-                + len(self.yellow)
-                + len(self.reset)
-                + 1
-            )
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, reg)
+        self.term.info('foo bar')
+
+        ret = mock_stdout.getvalue()
+
+        self.assertEqual(len(ret), expected_len)
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ok(self, mock_stdout):
-        term = Terminal()
+        width = self.term.get_width()
+        expected_len = width + len(self.green) + len(self.reset) + 1
 
-        width, _ = os.get_terminal_size()
-        est_len = width + len(self.green) + len(self.reset) + 1
-
-        term.ok('foo bar')
-
-        # get the printed output
-        ret = mock_stdout.getvalue()
-
-        # build the estimated output
         status = '[ {}ok{} ]\n'.format(self.green, self.reset)
         msg = 'foo bar'
-        sep = ' ' * (est_len - (len(msg) + len(status)))
-        reg = msg + sep + status
+        sep = ' ' * (expected_len - len(msg) - len(status))
+        expected_msg = msg + sep + status
 
-        # assert length and output and terminal width
-        self.assertIsNotNone(term._width)
-        self.assertEqual(term._width, width)
-        if width is 0:
-            est_len = (
-                len(msg)
-                + len('[ ok ]')
-                + len(self.yellow)
-                + len(self.reset)
-                + 1
-            )
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, reg)
+        self.term.ok('foo bar')
+
+        ret = mock_stdout.getvalue()
+
+        self.assertEqual(len(ret), expected_len)
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_warning(self, mock_stdout):
-        term = Terminal()
+        width = self.term.get_width()
+        expected_len = width + len(self.yellow) + len(self.reset) + 1
 
-        width, _ = os.get_terminal_size()
-        est_len = width + len(self.yellow) + len(self.reset) + 1
+        msg = 'foo bar'
 
-        term.warning('foo bar')
+        status = '[ {}warning{} ]\n'.format(self.yellow, self.reset)
+        sep = ' ' * (expected_len - len(msg) - len(status))
+
+        expected_msg = msg + sep + status
+
+        self.term.warning(msg)
 
         ret = mock_stdout.getvalue()
-        status = '[ {}warning{} ]\n'.format(self.yellow, self.reset)
-        msg = 'foo bar'
-        sep = ' ' * (est_len - (len(msg) + len(status)))
 
-        reg = msg + sep + status
-
-        self.assertIsNotNone(term._width)
-        self.assertEqual(term._width, width)
-        if width is 0:
-            est_len = (
-                len(msg)
-                + len('[ warning ]')
-                + len(self.yellow)
-                + len(self.reset)
-                + 1
-            )
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, reg)
+        self.assertEqual(len(ret), expected_len)
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_print(self, mock_stdout):
         term = Terminal()
 
-        msg = 'foo bar\n'
-        est_len = len(msg)
+        expected_msg = 'foo bar\n'
 
         term.print('foo bar')
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, msg)
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_add_indent(self, mock_stdout):
         term = Terminal()
+
         i = 6
-        msg = ' ' * i + 'foo\n'
-        est_len = len(msg)
+        expected_msg = ' ' * i + 'foo\n'
 
         term.add_indent(i)
         term.print('foo')
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, msg)
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
 
         # clear the buffer
         mock_stdout.truncate(0)
         mock_stdout.seek(0)
 
         j = 4
-        msg = ' ' * (i + j) + 'bar\n'
-        est_len = len(msg)
+        expected_msg = ' ' * (i + j) + 'bar\n'
+
         term.add_indent(j)
         term.print('bar')
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, msg)
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_with_indent(self, mock_stdout):
         term = Terminal()
 
+        expected_msg = '  foo\n'
+
         with term.indent(2):
-            msg = '  foo\n'
-            est_len = len(msg)
             term.print('foo')
 
             ret = mock_stdout.getvalue()
 
-            # self.assertEqual(len(ret), est_len)
-            self.assertEqual(ret, msg)
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
 
         # clear the buffer
         mock_stdout.truncate(0)
@@ -250,13 +195,12 @@ class TerminalTestCase(unittest.TestCase):
 
         term.print('bar')
 
-        msg = 'bar\n'
-        est_len = len(msg)
+        expected_msg = 'bar\n'
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), est_len)
-        self.assertEqual(ret, msg)
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Ensure less issues with calculating a terminal width
* Add a single place to query the terminal width
* Improve readability and reliability of the terminal tests

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [n/a] Documentation
