### PR TITLE
Recommend poetry mode instead of pipenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Activation of the git hooks must be done manually with `autohooks activate`
   always. Using source distributions and a setuptools extension to activate the
   hooks isn't reliable at all [#52](https://github.com/greenbone/autohooks/pull/52)
+* Recommend the `poetry` mode instead of the `pipenv` mode. poetry is more
+  reliable then pipenv [#55](https://github.com/greenbone/autohooks/pull/55)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   always. Using source distributions and a setuptools extension to activate the
   hooks isn't reliable at all [#52](https://github.com/greenbone/autohooks/pull/52)
 * Recommend the `poetry` mode instead of the `pipenv` mode. poetry is more
-  reliable then pipenv [#55](https://github.com/greenbone/autohooks/pull/55)
+  reliable than pipenv [#55](https://github.com/greenbone/autohooks/pull/55)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ installation is deterministic and reliable between different developer setups.
 In contrast to the `pythonpath` mode the activation of the virtual environment
 provided by [pipenv] is done automatically in the background.
 
-Using the `pipenv` mode is highly recommended.
-
 ### Poetry Mode
 
 Like with the [pipenv mode](#pipenv-mode), it is possible to run autohooks in a
 dedicated environment controlled by [poetry]. By using the `poetry` mode the
 virtual environment will be activated automatically in the background when
 executing the autohooks based git commit hook.
+
+Using the `poetry` mode is highly recommended.
 
 ## Installing autohooks
 


### PR DESCRIPTION
Due to the long inactivity of the pipenv project the tools has fallen
behind poetry and really has some strange quirks. poetry is a bit
cleaner and seems to win the race. By using poetry also the issues with
dependabot are fixed.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [x] Documentation
