### PR TITLE
Line-breaks and other improvements for the terminal output

### DIFF
--- a/autohooks/precommit/run.py
+++ b/autohooks/precommit/run.py
@@ -100,17 +100,17 @@ def run() -> int:
     if plugins.is_dir():
         sys.path.append(plugins_dir_name)
 
-    term.print('autohooks => pre-commit')
+    term.bold_info('autohooks => pre-commit')
 
     with autohooks_module_path(), term.indent():
         for name in config.get_pre_commit_script_names():
-            term.print('Running {}'.format(name))
+            term.info('Running {}'.format(name))
 
             with term.indent():
                 try:
                     plugin = load_plugin(name)
                     if not has_precommit_function(plugin):
-                        term.error(
+                        term.fail(
                             'No precommit function found in plugin {}. '
                             'Your autohooks settings may be invalid.'.format(
                                 name

--- a/autohooks/terminal.py
+++ b/autohooks/terminal.py
@@ -16,10 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from shutil import get_terminal_size
-from enum import Enum
 from contextlib import contextmanager
-
+from enum import Enum
+from shutil import get_terminal_size
 from typing import Callable, Generator
 
 import colorful as cf
@@ -30,9 +29,9 @@ TERMINAL_SIZE_FALLBACK = (80, 24)  # use a small standard size as fallback
 class Signs(Enum):
     FAIL = u'\N{HEAVY MULTIPLICATION X}'
     ERROR = u'\N{MULTIPLICATION SIGN}'
-    WARNING = u'\N{warning sign}'
-    OK = u'\N{check mark}'
-    INFO = u'\N{information source}'
+    WARNING = u'\N{WARNING SIGN}'
+    OK = u'\N{CHECK MARK}'
+    INFO = u'\N{INFORMATION SOURCE}'
     NONE = ' '
 
     def __str__(self):
@@ -55,7 +54,7 @@ class Terminal:
         return width
 
     def _print_status(
-        self, message: str, status: str, color: Callable, style: Callable,
+        self, message: str, status: Signs, color: Callable, style: Callable,
     ) -> None:
         first_line = ''
         output = ''

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -183,6 +183,20 @@ class TerminalTestCase(unittest.TestCase):
         self.assertEqual(len(ret), len(expected_msg))
         self.assertEqual(ret, expected_msg)
 
+        # clear the buffer
+        mock_stdout.truncate(0)
+        mock_stdout.seek(0)
+
+        expected_msg = self.reset('  bar').styled_string + '\n'
+
+        self.term.reset_indent()
+        self.term.print('bar')
+
+        ret = mock_stdout.getvalue()
+
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
+
     @patch('sys.stdout', new_callable=StringIO)
     def test_with_indent(self, mock_stdout):
         expected_msg = self.reset('    foo').styled_string + '\n'

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -24,7 +24,7 @@ from unittest.mock import patch, MagicMock
 
 import colorful as cf
 
-from autohooks.terminal import Terminal
+from autohooks.terminal import Terminal, Signs
 
 
 class TerminalTestCase(unittest.TestCase):
@@ -35,110 +35,92 @@ class TerminalTestCase(unittest.TestCase):
         self.green = cf.green.style[0]
         self.yellow = cf.yellow.style[0]
         self.cyan = cf.cyan.style[0]
-        self.reset = cf.black.style[
-            1
-        ]  # every colors second value is the reset value ...
+        self.reset = cf.black.style[1]
+        # every colors second value is the reset value ...
         self.term = Terminal()
         self.term.get_width = MagicMock(return_value=80)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_error(self, mock_stdout):
+        status = '{}{}{} '.format(self.red, Signs.ERROR, self.reset)
         msg = 'foo bar'
 
-        width = self.term.get_width()
-        expected_len = width + len(self.red) + len(self.reset) + 1
-
-        status = '[ {}error{} ]\n'.format(self.red, self.reset)
-        sep = ' ' * (expected_len - len(msg) - len(status))
-
-        expected_msg = msg + sep + status
+        expected_len = len(status) + len(msg)
+        expected_msg = '{}{}\n'.format(status, msg)
 
         self.term.error(msg)
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), expected_len)
         self.assertEqual(ret, expected_msg)
+        self.assertEqual(len(ret), expected_len)
 
     @patch('sys.stdout', new_callable=StringIO)
-    def test_fail(self, mock_stdout):
-        width = self.term.get_width()
-        expected_len = width + len(self.red) + len(self.reset) + 1
-
-        status = '[ {}fail{} ]\n'.format(self.red, self.reset)
+    def test_fail_with_indent(self, mock_stdout):
+        status = '{}{}{} '.format(self.red, Signs.FAIL, self.reset)
         msg = 'foo bar baz'
-        sep = ' ' * (expected_len - len(msg) - len(status))
 
-        expected_msg = msg + sep + status
+        expected_len = len(status) + len(msg)
+        expected_msg = '{}{}\n'.format(status, msg)
 
         self.term.fail('foo bar baz')
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), expected_len)
         self.assertEqual(ret, expected_msg)
+        self.assertEqual(len(ret), expected_len)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_info(self, mock_stdout):
-        width = self.term.get_width()
-        expected_len = width + len(self.cyan) + len(self.reset) + 1
-
-        status = '[ {}info{} ]\n'.format(self.cyan, self.reset)
+        status = '{}{}{} '.format(self.cyan, Signs.INFO, self.reset)
         msg = 'foo bar'
-        sep = ' ' * (expected_len - len(msg) - len(status))
 
-        expected_msg = msg + sep + status
+        expected_len = len(status) + len(msg)
+        expected_msg = '{}{}\n'.format(status, msg)
 
         self.term.info('foo bar')
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), expected_len)
         self.assertEqual(ret, expected_msg)
+        self.assertEqual(len(ret), expected_len)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ok(self, mock_stdout):
-        width = self.term.get_width()
-        expected_len = width + len(self.green) + len(self.reset) + 1
-
-        status = '[ {}ok{} ]\n'.format(self.green, self.reset)
+        status = '{}{}{} '.format(self.green, Signs.OK, self.reset)
         msg = 'foo bar'
-        sep = ' ' * (expected_len - len(msg) - len(status))
-        expected_msg = msg + sep + status
+
+        expected_len = len(status) + len(msg)
+        expected_msg = '{}{}\n'.format(status, msg)
 
         self.term.ok('foo bar')
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), expected_len)
         self.assertEqual(ret, expected_msg)
+        self.assertEqual(len(ret), expected_len)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_warning(self, mock_stdout):
-        width = self.term.get_width()
-        expected_len = width + len(self.yellow) + len(self.reset) + 1
-
         msg = 'foo bar'
 
-        status = '[ {}warning{} ]\n'.format(self.yellow, self.reset)
-        sep = ' ' * (expected_len - len(msg) - len(status))
+        status = '{}{}{} '.format(self.yellow, Signs.WARNING, self.reset)
 
-        expected_msg = msg + sep + status
+        expected_len = len(status) + len(msg)
+        expected_msg = '{}{}\n'.format(status, msg)
 
         self.term.warning(msg)
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), expected_len)
         self.assertEqual(ret, expected_msg)
+        self.assertEqual(len(ret), expected_len)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_print(self, mock_stdout):
-        term = Terminal()
-
         expected_msg = 'foo bar\n'
 
-        term.print('foo bar')
+        self.term.print('foo bar')
 
         ret = mock_stdout.getvalue()
 
@@ -147,13 +129,11 @@ class TerminalTestCase(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_add_indent(self, mock_stdout):
-        term = Terminal()
-
         i = 6
         expected_msg = ' ' * i + 'foo\n'
 
-        term.add_indent(i)
-        term.print('foo')
+        self.term.add_indent(i)
+        self.term.print('foo')
 
         ret = mock_stdout.getvalue()
 
@@ -167,8 +147,8 @@ class TerminalTestCase(unittest.TestCase):
         j = 4
         expected_msg = ' ' * (i + j) + 'bar\n'
 
-        term.add_indent(j)
-        term.print('bar')
+        self.term.add_indent(j)
+        self.term.print('bar')
 
         ret = mock_stdout.getvalue()
 
@@ -176,26 +156,19 @@ class TerminalTestCase(unittest.TestCase):
         self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
-    def test_with_indent(self, mock_stdout):
-        term = Terminal()
+    def test_long_msg(self, mock_stdout):
+        expected_msg = (
+            'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed '
+            'diam non\numy eirmod tempor invidunt ut labore et dolore magna '
+            'aliquyam erat, s\ned diam voluptua.'
+        )
+        long_msg = (
+            'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, '
+            'sed diam nonumy eirmod tempor invidunt ut labore et dolore magna'
+            ' aliquyam erat, sed diam voluptua.'
+        )
 
-        expected_msg = '  foo\n'
-
-        with term.indent(2):
-            term.print('foo')
-
-            ret = mock_stdout.getvalue()
-
-        self.assertEqual(len(ret), len(expected_msg))
-        self.assertEqual(ret, expected_msg)
-
-        # clear the buffer
-        mock_stdout.truncate(0)
-        mock_stdout.seek(0)
-
-        term.print('bar')
-
-        expected_msg = 'bar\n'
+        self.term.print(long_msg)
 
         ret = mock_stdout.getvalue()
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -29,24 +29,26 @@ from autohooks.terminal import Terminal, Signs
 
 class TerminalTestCase(unittest.TestCase):
     def setUp(self):
-        self.maxDiff = None
+        self.maxDiff = 180
         # getting the bash-color-codes from the colorful module
-        self.red = cf.red.style[0]
-        self.green = cf.green.style[0]
-        self.yellow = cf.yellow.style[0]
-        self.cyan = cf.cyan.style[0]
-        self.reset = cf.black.style[1]
+        self.red = cf.red
+        self.green = cf.green
+        self.yellow = cf.yellow
+        self.cyan = cf.cyan
+        self.reset = cf.reset
         # every colors second value is the reset value ...
         self.term = Terminal()
         self.term.get_width = MagicMock(return_value=80)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_error(self, mock_stdout):
-        status = '{}{}{} '.format(self.red, Signs.ERROR, self.reset)
+        status = '{} '.format(self.red(Signs.ERROR))
         msg = 'foo bar'
 
-        expected_len = len(status) + len(msg)
-        expected_msg = '{}{}\n'.format(status, msg)
+        expected_msg = (
+            self.reset('{}{}'.format(status, msg)).styled_string + '\n'
+        )
+        expected_len = len(expected_msg)
 
         self.term.error(msg)
 
@@ -56,14 +58,16 @@ class TerminalTestCase(unittest.TestCase):
         self.assertEqual(len(ret), expected_len)
 
     @patch('sys.stdout', new_callable=StringIO)
-    def test_fail_with_indent(self, mock_stdout):
-        status = '{}{}{} '.format(self.red, Signs.FAIL, self.reset)
+    def test_fail(self, mock_stdout):
+        status = '{} '.format(self.red(Signs.FAIL))
         msg = 'foo bar baz'
 
-        expected_len = len(status) + len(msg)
-        expected_msg = '{}{}\n'.format(status, msg)
+        expected_msg = (
+            self.reset('{}{}'.format(status, msg)).styled_string + '\n'
+        )
+        expected_len = len(expected_msg)
 
-        self.term.fail('foo bar baz')
+        self.term.fail(msg)
 
         ret = mock_stdout.getvalue()
 
@@ -72,13 +76,15 @@ class TerminalTestCase(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_info(self, mock_stdout):
-        status = '{}{}{} '.format(self.cyan, Signs.INFO, self.reset)
+        status = '{} '.format(self.cyan(Signs.INFO))
         msg = 'foo bar'
 
-        expected_len = len(status) + len(msg)
-        expected_msg = '{}{}\n'.format(status, msg)
+        expected_msg = (
+            self.reset('{}{}'.format(status, msg)).styled_string + '\n'
+        )
+        expected_len = len(expected_msg)
 
-        self.term.info('foo bar')
+        self.term.info(msg)
 
         ret = mock_stdout.getvalue()
 
@@ -87,13 +93,15 @@ class TerminalTestCase(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_ok(self, mock_stdout):
-        status = '{}{}{} '.format(self.green, Signs.OK, self.reset)
+        status = '{} '.format(self.green(Signs.OK))
         msg = 'foo bar'
 
-        expected_len = len(status) + len(msg)
-        expected_msg = '{}{}\n'.format(status, msg)
+        expected_msg = (
+            self.reset('{}{}'.format(status, msg)).styled_string + '\n'
+        )
+        expected_len = len(expected_msg)
 
-        self.term.ok('foo bar')
+        self.term.ok(msg)
 
         ret = mock_stdout.getvalue()
 
@@ -104,10 +112,12 @@ class TerminalTestCase(unittest.TestCase):
     def test_warning(self, mock_stdout):
         msg = 'foo bar'
 
-        status = '{}{}{} '.format(self.yellow, Signs.WARNING, self.reset)
+        status = '{} '.format(self.yellow(Signs.WARNING))
 
-        expected_len = len(status) + len(msg)
-        expected_msg = '{}{}\n'.format(status, msg)
+        expected_msg = (
+            self.reset('{}{}'.format(status, msg)).styled_string + '\n'
+        )
+        expected_len = len(expected_msg)
 
         self.term.warning(msg)
 
@@ -118,7 +128,7 @@ class TerminalTestCase(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_print(self, mock_stdout):
-        expected_msg = 'foo bar\n'
+        expected_msg = self.reset('  foo bar').styled_string + '\n'
 
         self.term.print('foo bar')
 
@@ -130,9 +140,9 @@ class TerminalTestCase(unittest.TestCase):
     @patch('sys.stdout', new_callable=StringIO)
     def test_add_indent(self, mock_stdout):
         i = 6
-        expected_msg = ' ' * i + 'foo\n'
+        expected_msg = self.reset(' ' * i + 'foo').styled_string + '\n'
 
-        self.term.add_indent(i)
+        self.term.add_indent(i - 2)
         self.term.print('foo')
 
         ret = mock_stdout.getvalue()
@@ -145,7 +155,7 @@ class TerminalTestCase(unittest.TestCase):
         mock_stdout.seek(0)
 
         j = 4
-        expected_msg = ' ' * (i + j) + 'bar\n'
+        expected_msg = self.reset(' ' * (i + j) + 'bar').styled_string + '\n'
 
         self.term.add_indent(j)
         self.term.print('bar')
@@ -157,23 +167,27 @@ class TerminalTestCase(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_long_msg(self, mock_stdout):
-        expected_msg = (
-            'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed '
-            'diam non\numy eirmod tempor invidunt ut labore et dolore magna '
-            'aliquyam erat, s\ned diam voluptua.'
-        )
         long_msg = (
             'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, '
             'sed diam nonumy eirmod tempor invidunt ut labore et dolore magna'
             ' aliquyam erat, sed diam voluptua.'
         )
+        expected_msg = (
+            self.reset(
+                '  Lorem ipsum dolor sit amet, consetetur sadipscing elitr, '
+                'sed diam nonumy eirmo\n  d tempor invidunt ut labore et'
+                ' dolore magna aliquyam erat, sed diam voluptua.'
+            ).styled_string
+            + '\n'
+        )
+        expected_len = len(expected_msg)
 
         self.term.print(long_msg)
 
         ret = mock_stdout.getvalue()
 
-        self.assertEqual(len(ret), len(expected_msg))
         self.assertEqual(ret, expected_msg)
+        self.assertEqual(len(ret), expected_len)
 
 
 if __name__ == '__main__':

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -187,6 +187,23 @@ class TerminalTestCase(unittest.TestCase):
         mock_stdout.truncate(0)
         mock_stdout.seek(0)
 
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_reset_indent(self, mock_stdout):
+        i = 6
+        expected_msg = self.reset(' ' * i + 'foo').styled_string + '\n'
+
+        self.term.add_indent(i - 2)
+        self.term.print('foo')
+
+        ret = mock_stdout.getvalue()
+
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
+
+        # clear the buffer
+        mock_stdout.truncate(0)
+        mock_stdout.seek(0)
+
         expected_msg = self.reset('  bar').styled_string + '\n'
 
         self.term.reset_indent()

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -36,6 +36,7 @@ class TerminalTestCase(unittest.TestCase):
         self.yellow = cf.yellow
         self.cyan = cf.cyan
         self.reset = cf.reset
+        self.bold = cf.bold
         # every colors second value is the reset value ...
         self.term = Terminal()
         self.term.get_width = MagicMock(return_value=80)
@@ -85,6 +86,23 @@ class TerminalTestCase(unittest.TestCase):
         expected_len = len(expected_msg)
 
         self.term.info(msg)
+
+        ret = mock_stdout.getvalue()
+
+        self.assertEqual(ret, expected_msg)
+        self.assertEqual(len(ret), expected_len)
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_bold_info(self, mock_stdout):
+        status = '{} '.format(self.cyan(Signs.INFO))
+        msg = 'bold foo bar'
+
+        expected_msg = (
+            self.bold('{}{}'.format(status, msg)).styled_string + '\n'
+        )
+        expected_len = len(expected_msg)
+
+        self.term.bold_info(msg)
 
         ret = mock_stdout.getvalue()
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -185,12 +185,10 @@ class TerminalTestCase(unittest.TestCase):
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_with_indent(self, mock_stdout):
-        term = Terminal()
-
         expected_msg = self.reset('    foo').styled_string + '\n'
 
-        with term.indent(2):
-            term.print('foo')
+        with self.term.indent(2):
+            self.term.print('foo')
 
             ret = mock_stdout.getvalue()
 
@@ -201,9 +199,13 @@ class TerminalTestCase(unittest.TestCase):
         mock_stdout.truncate(0)
         mock_stdout.seek(0)
 
-        term.print('bar')
+        expected_msg = self.reset('  bar').styled_string + '\n'
+        self.term.print('bar')
 
-        expected_msg = 'bar\n'
+        ret = mock_stdout.getvalue()
+
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_long_msg(self, mock_stdout):

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -184,6 +184,28 @@ class TerminalTestCase(unittest.TestCase):
         self.assertEqual(ret, expected_msg)
 
     @patch('sys.stdout', new_callable=StringIO)
+    def test_with_indent(self, mock_stdout):
+        term = Terminal()
+
+        expected_msg = self.reset('    foo').styled_string + '\n'
+
+        with term.indent(2):
+            term.print('foo')
+
+            ret = mock_stdout.getvalue()
+
+        self.assertEqual(len(ret), len(expected_msg))
+        self.assertEqual(ret, expected_msg)
+
+        # clear the buffer
+        mock_stdout.truncate(0)
+        mock_stdout.seek(0)
+
+        term.print('bar')
+
+        expected_msg = 'bar\n'
+
+    @patch('sys.stdout', new_callable=StringIO)
     def test_long_msg(self, mock_stdout):
         long_msg = (
             'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, '


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

If a line is larger than the terminals width, it will be broken correctly ... hopefully.
Changed the status from right to left, from text to symbol ...

Example:

```
ℹ autohooks => pre-commit
ℹ     Running autohooks.plugins.black
✓         Running black on autohooks/precommit/run.py
✓         Running black on autohooks/terminal.py
✓         Running black on tests/test_terminal.py
ℹ     Running autohooks.plugins.pylint
************* Module terminal
autohooks/terminal.py:70:12: E0602: Undefined variable 'part_line' (undefined-variable)
************* Module tests.test_terminal
tests/test_terminal.py:160:0: C0301: Line too long (184/80) (line-too-long)
tests/test_terminal.py:161:0: C0301: Line too long (176/80) (line-too-long)
✖         Linting error(s) found in autohooks/precommit/run.py, autohooks/terminal.py, tests/test_terminal.py.
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
