### PR TITLE
Add mode pythonpathvenv as means of decoupling autohook venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/greenbone/autohooks/compare/v2.2.0...HEAD
 
+## [2.2.1.dev1 - 2020-10-09]
+
+### Added
+
+* New Mode `pythonpathvenv` which writes as shebang with `sys.executable` into the pre-commit hook decoupling autohook execution venv from development venv.
 
 ## [2.2.0] - 2020-08-28
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Welcome to **autohooks**!
 - [Requirements](#requirements)
 - [Modes](#modes)
   - [Pythonpath Mode](#pythonpath-mode)
+  - [Pythonpathvenv Mode](#pythonpathvenv-mode)
   - [Pipenv Mode](#pipenv-mode)
   - [Poetry Mode](#poetry-mode)
 - [Installing autohooks](#installing-autohooks)
@@ -96,6 +97,15 @@ environment but activating the environment has to be done manually.
 
 Therefore it is even possible to run different versions of autohooks by
 using the `pythonpath` mode and switching to a virtual environment.
+
+### Pythonpathvenv Mode
+
+With `pythonpathvenv` mode, things are very similar to `pythonpath` mode with the
+exception that the shebang path to the python binary is written in absolute
+path to the python binary which is used to execute `autohooks activate`.
+
+This should enable to use virtually any method of managing your venvs, including
+maintaining a separate venv for the purpose of autohooks management.
 
 ### Pipenv Mode
 

--- a/autohooks/cli/__init__.py
+++ b/autohooks/cli/__init__.py
@@ -49,7 +49,7 @@ def main():
         '-m',
         '--mode',
         dest='mode',
-        choices=[str(Mode.PYTHONPATH), str(Mode.PIPENV), str(Mode.POETRY)],
+        choices=[str(Mode.PYTHONPATH), str(Mode.PYTHONPATHVENV), str(Mode.PIPENV), str(Mode.POETRY)],
         help='Mode for loading autohooks during hook execution. Either load '
         'autohooks from the PYTHON_PATH, via pipenv or via poetry.',
     )

--- a/autohooks/hooks.py
+++ b/autohooks/hooks.py
@@ -24,6 +24,7 @@ from autohooks.template import (
     PIPENV_SHEBANG,
     POETRY_SHEBANG,
     PYTHON3_SHEBANG,
+    PY_VENV_SHEBANG,
     TEMPLATE_VERSION,
     PreCommitTemplate,
 )
@@ -70,6 +71,8 @@ class PreCommitHook:
 
         if shebang == PYTHON3_SHEBANG:
             return Mode.PYTHONPATH
+        if shebang == PY_VENV_SHEBANG:
+            return Mode.PYTHONPATHVENV
         if shebang == POETRY_SHEBANG:
             return Mode.POETRY
         if shebang == PIPENV_SHEBANG:

--- a/autohooks/settings.py
+++ b/autohooks/settings.py
@@ -22,6 +22,7 @@ class Mode(Enum):
     PIPENV = 1
     PYTHONPATH = 2
     POETRY = 3
+    PYTHONPATHVENV = 4
     UNDEFINED = -1
     UNKNOWN = -2
 
@@ -31,6 +32,8 @@ class Mode(Enum):
             return Mode.PIPENV
         if self.value == Mode.POETRY.value:
             return Mode.POETRY
+        if self.value == Mode.PYTHONPATHVENV.value:
+            return Mode.PYTHONPATHVENV
         return Mode.PYTHONPATH
 
     @staticmethod

--- a/autohooks/template.py
+++ b/autohooks/template.py
@@ -17,12 +17,14 @@
 
 from pathlib import Path
 from string import Template
+from sys import executable
 
 from autohooks.settings import Mode
 from autohooks.utils import get_autohooks_directory_path
 
 
 PYTHON3_SHEBANG = '/usr/bin/env python3'
+PY_VENV_SHEBANG = '/usr/bin/env ' + executable
 PIPENV_SHEBANG = '/usr/bin/env -S pipenv run python3'
 POETRY_SHEBANG = '/usr/bin/env -S poetry run python3'
 
@@ -52,6 +54,8 @@ class PreCommitTemplate:
             params['SHEBANG'] = PIPENV_SHEBANG
         elif mode == Mode.POETRY:
             params['SHEBANG'] = POETRY_SHEBANG
+        elif mode == Mode.PYTHONPATHVENV:
+            params['SHEBANG'] = PY_VENV_SHEBANG
         else:
             params['SHEBANG'] = PYTHON3_SHEBANG
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,6 +111,18 @@ class AutohooksConfigTestCase(unittest.TestCase):
 
         self.assertEqual(len(config.get_pre_commit_script_names()), 0)
 
+    def test_get_mode_pythonpathvenv(self):
+        config = AutohooksConfig(
+            {'tool': {'autohooks': {'mode': 'pythonpathvenv'}}}
+        )
+
+        self.assertTrue(config.has_config())
+        self.assertTrue(config.has_autohooks_config())
+        self.assertTrue(config.is_autohooks_enabled())
+        self.assertEqual(config.get_mode(), Mode.PYTHONPATHVENV)
+
+        self.assertEqual(len(config.get_pre_commit_script_names()), 0)
+
     def test_get_mode_unknown(self):
         config = AutohooksConfig({'tool': {'autohooks': {'mode': 'foo'}}})
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -30,6 +30,7 @@ from autohooks.template import (
     PIPENV_SHEBANG,
     POETRY_SHEBANG,
     PYTHON3_SHEBANG,
+    PY_VENV_SHEBANG,
 )
 from autohooks.utils import exec_git
 
@@ -214,6 +215,19 @@ class WriteTestCase(unittest.TestCase):
         args, _kwargs = write_path.write_text.call_args
         text = args[0]
         self.assertRegex(text, '^#!{} *'.format(PYTHON3_SHEBANG))
+
+
+    def test_pythonpathvenv_mode(self):
+        write_path = Mock()
+        pre_commit_hook = PreCommitHook(write_path)
+        pre_commit_hook.write(mode=Mode.PYTHONPATHVENV)
+
+        write_path.chmod.assert_called_with(0o775)
+        self.assertTrue(write_path.write_text.called)
+
+        args, _kwargs = write_path.write_text.call_args
+        text = args[0]
+        self.assertRegex(text, '^#!{} *'.format(PY_VENV_SHEBANG))
 
 
 class StrTestCase(unittest.TestCase):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,6 +24,7 @@ class ModeTestCase(unittest.TestCase):
     def test_get_effective_mode(self):
         self.assertEqual(Mode.PIPENV.get_effective_mode(), Mode.PIPENV)
         self.assertEqual(Mode.PYTHONPATH.get_effective_mode(), Mode.PYTHONPATH)
+        self.assertEqual(Mode.PYTHONPATHVENV.get_effective_mode(), Mode.PYTHONPATHVENV)
         self.assertEqual(Mode.POETRY.get_effective_mode(), Mode.POETRY)
         self.assertEqual(Mode.UNDEFINED.get_effective_mode(), Mode.PYTHONPATH)
         self.assertEqual(Mode.UNKNOWN.get_effective_mode(), Mode.PYTHONPATH)
@@ -35,6 +36,10 @@ class ModeTestCase(unittest.TestCase):
     def test_get_pythonpath_mode_from_string(self):
         self.assertEqual(Mode.from_string('pythonpath'), Mode.PYTHONPATH)
         self.assertEqual(Mode.from_string('PYTHONPATH'), Mode.PYTHONPATH)
+
+    def test_get_pythonpathvenv_mode_from_string(self):
+        self.assertEqual(Mode.from_string('pythonpathvenv'), Mode.PYTHONPATHVENV)
+        self.assertEqual(Mode.from_string('PYTHONPATHVENV'), Mode.PYTHONPATHVENV)
 
     def test_get_poetry_mode_from_string(self):
         self.assertEqual(Mode.from_string('poetry'), Mode.POETRY)
@@ -48,6 +53,7 @@ class ModeTestCase(unittest.TestCase):
     def test_string_conversion(self):
         self.assertEqual(str(Mode.PIPENV), 'pipenv')
         self.assertEqual(str(Mode.PYTHONPATH), 'pythonpath')
+        self.assertEqual(str(Mode.PYTHONPATHVENV), 'pythonpathvenv')
         self.assertEqual(str(Mode.POETRY), 'poetry')
         self.assertEqual(str(Mode.UNKNOWN), 'unknown')
         self.assertEqual(str(Mode.UNDEFINED), 'undefined')


### PR DESCRIPTION
**What**:

This PR adds a fourth Mode `pythonpathvenv` which is different in that it writes a different shebang that points to the python executables absolute path effectively enabling any use case that might not been covered by the other modes. One (my) example is described in the **why** section below.

**Why**:

My employer uses tox (https://pypi.org/project/tox/) and there i wanted to have the possibility to add an environment for the purpose of running the autohook commands. This is at least my context.

When a user is in the development venv or global scope during development aka during authoring commits, one might not have autohook available while using `#!/usr/bin/env python3`. At least in my use case I'm using a separate venv for autohook. When i run `autohook activate` from within this venv i want it to install the hook script pointing to the venv that i've been using while running the command via tox.

**How**:

I added tests to the best of my knowledge.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [x] Documentation
