### PR TITLE
Drop Python 3.5 and 3.6 support, add Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,6 @@
 version: 2.1
 
 executors:
-  python-35:
-    docker:
-      - image: circleci/python:3.5
-    working_directory: ~/repo
-  python-36:
-    docker:
-      - image: circleci/python:3.6
-    working_directory: ~/repo
   python-37:
     docker:
       - image: circleci/python:3.7
@@ -16,6 +8,10 @@ executors:
   python-38:
     docker:
       - image: circleci/python:3.8
+    working_directory: ~/repo
+  python-39:
+    docker:
+      - image: circleci/python:3.9
     working_directory: ~/repo
 
 commands:
@@ -115,22 +111,10 @@ commands:
             poetry run twine upload dist/*
 
 jobs:
-  build-35:
-    executor: python-35
+  lint-37:
+    executor: python-37
     steps:
-      - build
-  test-35:
-    executor: python-35
-    steps:
-      - test
-  build-36:
-    executor: python-36
-    steps:
-      - build
-  test-36:
-    executor: python-36
-    steps:
-      - test
+      - lint
   build-37:
     executor: python-37
     steps:
@@ -139,16 +123,20 @@ jobs:
     executor: python-37
     steps:
       - test-with-codecov
-  lint-37:
-    executor: python-37
-    steps:
-      - lint
   build-38:
     executor: python-38
     steps:
       - build
   test-38:
     executor: python-38
+    steps:
+      - test
+  build-39:
+    executor: python-39
+    steps:
+      - build
+  test-39:
+    executor: python-39
     steps:
       - test
   deploy-37:
@@ -160,15 +148,13 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build-35
-      - test-35
-      - build-36
-      - test-36
       - build-37
       - test-37
       - lint-37
       - build-38
       - test-38
+      - build-39
+      - test-39
   build_and_deploy:
     jobs:
       - build-37:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+* CI tests Python 3.9 now. [#97](https://github.com/greenbone/autohooks/pull/97)
+
 ### Changed
 ### Deprecated
+* Dropped Python 3.5 and Python 3.6 support. Python 3.7+ is required now. [#97](https://github.com/greenbone/autohooks/pull/97)
+
 ### Removed
 ### Fixed
+* Fix split-string (`-S`) to support all operating systems. [#89](https://github.com/greenbone/autohooks/pull/89)
 
 [Unreleased]: https://github.com/greenbone/autohooks/compare/v2.2.0...HEAD
-
 
 ## [2.2.0] - 2020-08-28
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ by supporting different modes.
 
 ## Requirements
 
-autohooks only supports Python 3.7+.
+Python 3.7+ is required for autohooks.
 
 ## Modes
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ by supporting different modes.
 
 ## Requirements
 
-autohooks supports Python 3.5+. For development Python 3.6+ is required.
+autohooks only supports Python 3.7+.
 
 ## Modes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ tomlkit = "^0.5.11"
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.3"
 autohooks-plugin-pylint = "^1.2.0"
-autohooks-plugin-black "^1.2.0"
+autohooks-plugin-black = "^1.2.0"
 black = "20.8b1"
 rope = "^0.18.0"
 pontos = "^0.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ classifiers=[
   "Environment :: Console",
   "Intended Audience :: Developers",
   "Intended Audience :: System Administrators",
-  "Programming Language :: Python :: 3.5",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Software Development :: Version Control :: Git",
@@ -46,7 +45,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.7"
 colorful = "^0.5.4"
 packaging = "^20.3"
 tomlkit = "^0.5.11"
@@ -54,17 +53,17 @@ tomlkit = "^0.5.11"
 [tool.poetry.dev-dependencies]
 pylint = "^2.5.3"
 autohooks-plugin-pylint = "^1.2.0"
-autohooks-plugin-black = {version = "^1.2.0", python = "^3.6"}
-black = {version = "20.8b1", python = "^3.6"}
+autohooks-plugin-black "^1.2.0"
+black = "20.8b1"
 rope = "^0.18.0"
-pontos = {version = "^0.3.1", python = "^3.7"}
+pontos = "^0.3.1"
 
 [tool.poetry.scripts]
 autohooks = "autohooks.cli:main"
 
 [tool.black]
 line-length = 80
-target-version = ['py35', 'py36', 'py37', 'py38']
+target-version = ['py37', 'py38']
 skip-string-normalization = true
 exclude = '''
 /(


### PR DESCRIPTION
**What**:

Drop Python 3.5 and 3.6 support, add Python 3.9

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Python 3.5 is deprecated.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
