### PR TITLE
Fix config test for tomlkit 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ $ cd autohooks && git log
 ### Deprecated
 ### Removed
 ### Fixed
+* Fix getting a value from the config with tomlkit >= 0.7.1 [#132](https://github.com/greenbone/autohooks/pull/132)
 
 [Unreleased]: https://github.com/greenbone/autohooks/compare/v21.3.0...HEAD
 

--- a/autohooks/config.py
+++ b/autohooks/config.py
@@ -34,7 +34,7 @@ class Config:
         config_dict = self._config_dict
 
         for key in keys:
-            config_dict = config_dict.get(key, {})
+            config_dict = config_dict.get(key, {}).copy()
 
         return Config(config_dict)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -276,7 +276,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomlkit"
-version = "0.7.0"
+version = "0.7.2"
 description = "Style preserving TOML library"
 category = "main"
 optional = false
@@ -496,8 +496,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
-    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
+    {file = "tomlkit-0.7.2-py2.py3-none-any.whl", hash = "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117"},
+    {file = "tomlkit-0.7.2.tar.gz", hash = "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},


### PR DESCRIPTION
**What**:

Fix a nasty issue with testing getting a config value with up to date tomlkit 0.7.2

**Why**:

The config_dict is some tomlkit extended dict class. With some tomlkit
0.7.1 or 0.7.2 a single test broke. At some place some of this dict
classes might return a proxy to a class and in the next iteration this
proxy doesn't work anymore because something is freed internally.
Therefore always copy the object to not free the data.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
