### PR TITLE
Autohooks now uses getcwd instead of os.environ['PWD']

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -10,6 +10,9 @@ jobs:
       GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
       GITHUB_MAIL: ${{ secrets.GREENBONE_BOT_MAIL }}
       GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
+      GPG_KEY: ${{ secrets.GPG_KEY }}
+      GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     name: Build and release with pontos
     # If the label 'make release' is set. If PR is closed because of an merge
     if: contains( github.event.pull_request.labels.*.name, 'make release') && github.event.pull_request.merged == true
@@ -28,10 +31,27 @@ jobs:
       run: |
         git config --global user.name "${{ env.GITHUB_USER }}"
         git config --global user.email "${{ env.GITHUB_MAIL }}"
-        git remote set-url origin https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        git remote set-url origin \
+          https://${{ env.GITHUB_TOKEN }}@github.com/${{ github.repository }}
     - name: Prepare release with pontos
       run: |
         poetry run pontos-release prepare --calendar
+        echo "VERSION=$(poetry run pontos-version show)" >> $GITHUB_ENV
     - name: Release with pontos
       run: |
         poetry run pontos-release release
+    - name: Import key from secrets
+      run: |
+        echo -e "${{ env.GPG_KEY }}" >> tmp.file
+        gpg                                        \
+          --pinentry-mode loopback                 \
+          --passphrase ${{ env.GPG_PASSPHRASE }}   \
+          --import tmp.file
+        rm tmp.file
+    - name: Sign with pontos-release sign
+      run: |
+        echo "Signing assets for ${{env.VERSION}}"
+        poetry run pontos-release sign             \
+          --signing-key ${{ env.GPG_FINGERPRINT }} \
+          --passphrase ${{ env.GPG_PASSPHRASE }}   \
+          --release-version ${{ env.VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ $ cd autohooks && git log
 ## [Unreleased]
 ### Added
 ### Changed
-* Using `os.getcwd()` instead of `os.environ['PWD']`, to make autohooks more reliable for windows. [#165](https://github.com/greenbone/autohooks/pull/165)
+* Using `Path.cwd()` instead of `os.environ['PWD']`, to make autohooks more reliable for windows. [#165](https://github.com/greenbone/autohooks/pull/165)
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ $ cd autohooks && git log
 ## [Unreleased]
 ### Added
 ### Changed
+* Using `os.getcwd()` instead of `os.environ['PWD']`, to make autohooks more reliable for windows. [#165](https://github.com/greenbone/autohooks/pull/165)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/autohooks/utils.py
+++ b/autohooks/utils.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import shlex
 import subprocess
 
@@ -43,7 +42,7 @@ def exec_git(*args: str, ignore_errors: bool = False) -> str:
 
 
 def get_git_directory_path() -> Path:
-    pwd = os.getcwd()
+    pwd = Path.cwd()
 
     try:
         git_dir = exec_git('-C', pwd, 'rev-parse', '--git-dir').rstrip()
@@ -53,7 +52,7 @@ def get_git_directory_path() -> Path:
         )
         raise e from None
 
-    if pwd and not pwd in git_dir:
+    if pwd and str(pwd) not in git_dir:
         git_dir_path = Path(pwd) / git_dir
     else:
         git_dir_path = Path(git_dir)
@@ -82,7 +81,7 @@ def is_project_root(path: Path) -> bool:
 
 def get_project_root_path(path: Path = None) -> Path:
     if path is None:
-        path = Path(os.getcwd())
+        path = Path.cwd()
 
     path.resolve()
 

--- a/autohooks/utils.py
+++ b/autohooks/utils.py
@@ -43,7 +43,7 @@ def exec_git(*args: str, ignore_errors: bool = False) -> str:
 
 
 def get_git_directory_path() -> Path:
-    pwd = os.environ['PWD']
+    pwd = os.getcwd()
 
     try:
         git_dir = exec_git('-C', pwd, 'rev-parse', '--git-dir').rstrip()
@@ -82,7 +82,7 @@ def is_project_root(path: Path) -> bool:
 
 def get_project_root_path(path: Path = None) -> Path:
     if path is None:
-        path = Path(os.environ['PWD'])
+        path = Path(os.getcwd())
 
     path.resolve()
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -49,7 +49,7 @@ class GitDirTestCase(unittest.TestCase):
 
         self.assertTrue(self.git_dir_path.exists())
 
-        os.environ['PWD'] = str(self.temp_dir_path)
+        os.chdir(str(self.temp_dir_path))
 
     def tearDown(self):
         self.tempdir.cleanup()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,7 @@ class GitHookDirPathTestCase(unittest.TestCase):
 
             exec_git('-C', str(temp_path), 'init')
 
-            os.environ['PWD'] = str(temp_path)
+            os.chdir(str(temp_path))
 
             git_dir_path = (temp_path / '.git').resolve()
 
@@ -96,7 +96,7 @@ class IsProjectRootTestCase(unittest.TestCase):
 class GetProjectRootPath(unittest.TestCase):
     def setUp(self):
         self.tempdir = TemporaryDirectory()
-        self.temp_path = Path(self.tempdir.name)
+        self.temp_path = Path(self.tempdir.name).resolve()
 
     def tearDown(self):
         self.tempdir.cleanup()
@@ -130,7 +130,7 @@ class GetProjectRootPath(unittest.TestCase):
         sub_path = self.temp_path / 'foo'
         sub_path.mkdir()
 
-        os.environ['PWD'] = str(sub_path)
+        os.chdir(str(self.temp_path))
 
         root_path = get_project_root_path()
 
@@ -140,7 +140,7 @@ class GetProjectRootPath(unittest.TestCase):
 class GetProjectAutohooksPluginsPathTestCase(unittest.TestCase):
     def setUp(self):
         self.tempdir = TemporaryDirectory()
-        self.temp_path = Path(self.tempdir.name)
+        self.temp_path = Path(self.tempdir.name).resolve()
 
         setup_py = self.temp_path / 'setup.py'
         setup_py.touch()
@@ -156,7 +156,7 @@ class GetProjectAutohooksPluginsPathTestCase(unittest.TestCase):
         self.assertEqual(autohooks_plugins_path, self.temp_path / '.autohooks')
 
     def test_with_env_pwd(self):
-        os.environ['PWD'] = str(self.temp_path)
+        os.chdir(str(self.temp_path))
 
         autohooks_plugins_path = get_project_autohooks_plugins_path()
         self.assertEqual(autohooks_plugins_path, self.temp_path / '.autohooks')
@@ -165,7 +165,7 @@ class GetProjectAutohooksPluginsPathTestCase(unittest.TestCase):
 class GetPyProjectTomlPathTestCase(unittest.TestCase):
     def setUp(self):
         self.tempdir = TemporaryDirectory()
-        self.temp_path = Path(self.tempdir.name)
+        self.temp_path = Path(self.tempdir.name).resolve()
 
     def tearDown(self):
         self.tempdir.cleanup()
@@ -181,7 +181,7 @@ class GetPyProjectTomlPathTestCase(unittest.TestCase):
         self.assertEqual(pyproject_toml_path, self.temp_path / 'pyproject.toml')
 
     def test_with_env_pwd(self):
-        os.environ['PWD'] = str(self.temp_path)
+        os.chdir(str(self.temp_path))
 
         setup_py = self.temp_path / 'setup.py'
         setup_py.touch()
@@ -193,7 +193,7 @@ class GetPyProjectTomlPathTestCase(unittest.TestCase):
 class GetGitDirectoryPath(unittest.TestCase):
     def setUp(self):
         self.tempdir = TemporaryDirectory()
-        self.temp_path = Path(self.tempdir.name)
+        self.temp_path = Path(self.tempdir.name).resolve()
 
         exec_git('-C', str(self.temp_path), 'init')
 
@@ -205,7 +205,7 @@ class GetGitDirectoryPath(unittest.TestCase):
         self.tempdir.cleanup()
 
     def test_with_root_dir(self):
-        os.environ['PWD'] = str(self.temp_path)
+        os.chdir(str(self.temp_path))
 
         git_dir_path = get_git_directory_path()
         self.assertEqual(git_dir_path, self.git_dir_path.resolve())
@@ -214,7 +214,7 @@ class GetGitDirectoryPath(unittest.TestCase):
         sub_path = self.temp_path / 'foo'
         sub_path.mkdir()
 
-        os.environ['PWD'] = str(sub_path)
+        os.chdir(str(self.temp_path))
 
         git_dir_path = get_git_directory_path()
         self.assertEqual(git_dir_path, self.git_dir_path)


### PR DESCRIPTION
**What**:

* Using `getcwd` instead of `os.environ['PWD']`

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* to fix Windows (?)

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/autohooks/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
