### PR TITLE
Change: Remove direct dependency on packaging

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -369,7 +369,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c21119458a7d1c00a2698961f29400c85f678997043e1e90ca7ce1f28b9f4820"
+content-hash = "bea20a7d7a39cf61590f19fe32a79177564887d72e3c3e1909fec89eb643a890"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.7"
 colorful = "^0.5.4"
-packaging = "^20.3"
 tomlkit = ">=0.5.11"
 pontos = "^22.4.0"
 


### PR DESCRIPTION
**What**:

Remove direct dependency on packaging

**Why**:

The packaging library is not used in autohooks directly.

Fixes #322

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
- [ ] Documentation
