### PR TITLE
Plugin CLI

### DIFF
--- a/autohooks/cli/__init__.py
+++ b/autohooks/cli/__init__.py
@@ -56,8 +56,12 @@ def main():
         help="Mode for loading autohooks during hook execution. Either load "
         "autohooks from the PYTHON_PATH, via pipenv or via poetry.",
     )
+    activate_parser.set_defaults(func=install_hooks)
 
-    subparsers.add_parser("check", help="Check installed pre-commit hook")
+    check_parser = subparsers.add_parser(
+        "check", help="Check installed pre-commit hook"
+    )
+    check_parser.set_defaults(func=check_hooks)
 
     args = parser.parse_args()
 
@@ -65,10 +69,7 @@ def main():
         parser.print_usage()
 
     term = Terminal()
-    if args.command == "activate":
-        install_hooks(term, args)
-    elif args.command == "check":
-        check_hooks(term)
+    args.func(term, args)
 
 
 if __name__ == "__main__":

--- a/autohooks/cli/__init__.py
+++ b/autohooks/cli/__init__.py
@@ -21,6 +21,12 @@ import sys
 from autohooks.__version__ import __version__ as version
 from autohooks.cli.activate import install_hooks
 from autohooks.cli.check import check_hooks
+from autohooks.cli.plugins import (
+    add_plugins,
+    list_plugins,
+    plugins,
+    remove_plugins,
+)
 from autohooks.settings import Mode
 from autohooks.terminal import Terminal
 
@@ -63,6 +69,34 @@ def main():
         "check", help="Check installed pre-commit hook"
     )
     check_parser.set_defaults(func=check_hooks)
+
+    plugins_parser = subparsers.add_parser(
+        "plugins", help="Manage autohooks plugins"
+    )
+    plugins_parser.set_defaults(func=plugins)
+
+    plugins_subparsers = plugins_parser.add_subparsers(
+        dest="subcommand", required=True
+    )
+
+    add_plugins_parser = plugins_subparsers.add_parser(
+        "add", help="Add plugins."
+    )
+    add_plugins_parser.set_defaults(plugins_func=add_plugins)
+    add_plugins_parser.add_argument("name", nargs="+", help="Plugin(s) to add")
+
+    remove_plugins_parser = plugins_subparsers.add_parser(
+        "remove", help="Remove plugins."
+    )
+    remove_plugins_parser.set_defaults(plugins_func=remove_plugins)
+    remove_plugins_parser.add_argument(
+        "name", nargs="+", help="Plugin(s) to remove"
+    )
+
+    list_plugins_parser = plugins_subparsers.add_parser(
+        "list", help="List current used plugins."
+    )
+    list_plugins_parser.set_defaults(plugins_func=list_plugins)
 
     args = parser.parse_args()
 

--- a/autohooks/cli/__init__.py
+++ b/autohooks/cli/__init__.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import sys
 
 from autohooks.__version__ import __version__ as version
 from autohooks.cli.activate import install_hooks
@@ -67,6 +68,7 @@ def main():
 
     if not args.command:
         parser.print_usage()
+        sys.exit(1)
 
     term = Terminal()
     args.func(term, args)

--- a/autohooks/cli/check.py
+++ b/autohooks/cli/check.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from argparse import Namespace
 from pathlib import Path
 
 from autohooks.config import (
@@ -33,7 +34,8 @@ from autohooks.settings import Mode
 from autohooks.terminal import Terminal
 
 
-def check_hooks(term: Terminal) -> None:
+# pylint: disable=unused-argument
+def check_hooks(term: Terminal, args: Namespace) -> None:
     pre_commit_hook = PreCommitHook()
     check_pre_commit_hook(term, pre_commit_hook)
 

--- a/autohooks/cli/plugins.py
+++ b/autohooks/cli/plugins.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from argparse import Namespace
+from typing import Iterable
+
+from autohooks.config import load_config_from_pyproject_toml
+from autohooks.precommit.run import autohooks_module_path, check_plugin
+from autohooks.settings import AutohooksSettings
+from autohooks.terminal import Terminal
+from autohooks.utils import get_pyproject_toml_path
+
+
+def plugins(term: Terminal, args: Namespace) -> None:
+    args.plugins_func(term, args)
+
+
+def print_current_plugins(
+    term: Terminal, current_plugins: Iterable[str]
+) -> None:
+    """
+    Print the currently used plugins to the terminal
+    """
+    term.info("Currently used plugins:")
+    with term.indent(), autohooks_module_path():
+        if not current_plugins:
+            term.print("None")
+            return
+
+        for plugin in sorted(current_plugins):
+            result = check_plugin(plugin)
+            if result:
+                term.error(f'"{plugin}": {result}')
+            else:
+                term.ok(f'"{plugin}"')
+
+
+# pylint: disable=unused-argument
+def list_plugins(term: Terminal, args: Namespace) -> None:
+    """
+    CLI handler function to list the currently used plugins
+    """
+    pyproject_toml = get_pyproject_toml_path()
+    config = load_config_from_pyproject_toml(pyproject_toml)
+
+    current_plugins = (
+        config.settings.pre_commit if config.has_autohooks_config() else []
+    )
+    print_current_plugins(term, current_plugins)
+
+
+def add_plugins(term: Terminal, args: Namespace) -> None:
+    """
+    CLI handler function to add new plugins
+    """
+    pyproject_toml = get_pyproject_toml_path()
+    config = load_config_from_pyproject_toml(pyproject_toml)
+    plugins_to_add = set(args.name)
+
+    if config.has_autohooks_config():
+        settings = config.settings
+        existing_plugins = set(settings.pre_commit)
+        all_plugins = plugins_to_add | existing_plugins
+        duplicate_plugins = plugins_to_add & existing_plugins
+        new_plugins = plugins_to_add - existing_plugins
+        settings.pre_commit = all_plugins
+
+        if duplicate_plugins:
+            term.info("Skipped already used plugins:")
+            with term.indent():
+                for plugin in sorted(duplicate_plugins):
+                    term.warning(f'"{plugin}"')
+    else:
+        all_plugins = plugins_to_add
+        new_plugins = plugins_to_add
+        settings = AutohooksSettings(pre_commit=all_plugins)
+        config.settings = settings
+
+    settings.write(pyproject_toml)
+
+    if new_plugins:
+        term.info("Added plugins:")
+        with term.indent():
+            for plugin in sorted(new_plugins):
+                term.ok(f'"{plugin}"')
+
+    print_current_plugins(term, all_plugins)
+
+
+def remove_plugins(term: Terminal, args: Namespace) -> None:
+    """
+    CLI handler function to remove plugins
+    """
+    pyproject_toml = get_pyproject_toml_path()
+    config = load_config_from_pyproject_toml(pyproject_toml)
+    plugins_to_remove = set(args.name)
+
+    if config.has_autohooks_config():
+        settings = config.settings
+        existing_plugins = set(settings.pre_commit)
+        removed_plugins = existing_plugins & plugins_to_remove
+        all_plugins = existing_plugins - plugins_to_remove
+        skipped_plugins = plugins_to_remove - existing_plugins
+        settings.pre_commit = all_plugins
+
+        if skipped_plugins:
+            term.info("Skipped not used plugins:")
+            with term.indent():
+                for plugin in sorted(skipped_plugins):
+                    term.warning(f'"{plugin}"')
+
+        if removed_plugins:
+            term.info("Removed plugins:")
+            with term.indent():
+                for plugin in sorted(removed_plugins):
+                    term.ok(f'"{plugin}"')
+
+        settings.write(pyproject_toml)
+
+        print_current_plugins(term, all_plugins)
+    else:
+        term.warning("No plugins to remove.")

--- a/autohooks/precommit/run.py
+++ b/autohooks/precommit/run.py
@@ -75,6 +75,53 @@ def check_hook_mode(term: Terminal, config_mode: Mode, hook_mode: Mode) -> None:
         )
 
 
+class CheckPluginResult:
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class CheckPluginError(CheckPluginResult):
+    """
+    Raised if a plugin check failed
+    """
+
+
+class CheckPluginWarning(CheckPluginResult):
+    """
+    Used if a plugin check raises a warning
+    """
+
+
+def check_plugin(plugin_name: str) -> Optional[CheckPluginResult]:
+    """
+    Check if a plugin (Python module) is a valid and can be used
+
+    Returns:
+        A CheckPluginResult in case of an issue with the plugin
+    """
+    try:
+        plugin = load_plugin(plugin_name)
+        if not has_precommit_function(plugin):
+            return CheckPluginError(
+                f'Plugin "{plugin_name}" has no precommit '
+                "function. The function is required to run"
+                " the plugin as git pre commit hook."
+            )
+        elif not has_precommit_parameters(plugin):
+            return CheckPluginWarning(
+                f'Plugin "{plugin_name}" uses a deprecated '
+                "signature for its precommit function. It "
+                "is missing the **kwargs parameter."
+            )
+    except ImportError as e:
+        return CheckPluginError(
+            f'"{plugin_name}" is not a valid autohooks plugin. {e}'
+        )
+
+
 class ReportProgress:
     """
     A class to report progress of a plugin

--- a/autohooks/precommit/run.py
+++ b/autohooks/precommit/run.py
@@ -97,7 +97,7 @@ class CheckPluginWarning(CheckPluginResult):
 
 def check_plugin(plugin_name: str) -> Optional[CheckPluginResult]:
     """
-    Check if a plugin (Python module) is a valid and can be used
+    Check if a plugin (Python module) is valid and can be used
 
     Returns:
         A CheckPluginResult in case of an issue with the plugin

--- a/autohooks/settings.py
+++ b/autohooks/settings.py
@@ -82,7 +82,7 @@ class AutohooksSettings:
 
         config_dict = {
             "mode": str(self.mode.get_effective_mode()),
-            "pre-commit": self.pre_commit,
+            "pre-commit": sorted(self.pre_commit),
         }
 
         toml_doc["tool"]["autohooks"].update(config_dict)

--- a/autohooks/settings.py
+++ b/autohooks/settings.py
@@ -33,7 +33,6 @@ class Mode(Enum):
     UNKNOWN = -2
 
     def get_effective_mode(self):
-        # pylint: disable=comparison-with-callable
         if self.value == Mode.PIPENV.value:
             return Mode.PIPENV
         if self.value == Mode.PIPENV_MULTILINE.value:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -101,7 +101,7 @@ def tempgitdir() -> Generator[Path, None, None]:
 
 
 @contextmanager
-def testfile(
+def temp_file(
     content: str,
     *,
     name: Optional[str] = "test.toml",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -106,7 +106,18 @@ def testfile(
     *,
     name: Optional[str] = "test.toml",
     change_into: bool = False,
-) -> Path:
+) -> Generator[Path, None, None]:
+    """
+    A Context Manager to create a temporary file within a new temporary
+    directory. The temporary file and directory are removed when the context is
+    exited.
+
+    Args:
+        content: Content to write into the temporary file.
+        name: Name of the temporary file. "test.toml" by default.
+        change_into: Adjust the current working directory to the temporary
+            directory.
+    """
     with tempdir(change_into=change_into) as tmp_dir:
         test_file = tmp_dir / name
         test_file.write_text(content, encoding="utf8")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -125,5 +125,21 @@ def testfile(
 
 
 def unload_module(name: str) -> None:
+    """
+    Unload a Python module
+    """
     if name in sys.modules:
         del sys.modules[name]
+
+
+@contextmanager
+def ensure_unload_module(name: str) -> Generator[None, None, None]:
+    """
+    Ensure that a module gets removed even if an error occurs
+
+    Example:
+        with ensure_unload_module("foo.bar"):
+            do_something()
+    """
+    yield
+    unload_module(name)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -54,8 +54,13 @@ def tempgitdir() -> Generator[Path, None, None]:
 
 
 @contextmanager
-def testfile(content: str, *, name: Optional[str] = "test.toml") -> Path:
-    with tempdir() as tmp_dir:
+def testfile(
+    content: str,
+    *,
+    name: Optional[str] = "test.toml",
+    change_into: bool = False,
+) -> Path:
+    with tempdir(change_into=change_into) as tmp_dir:
         test_file = tmp_dir / name
         test_file.write_text(content, encoding="utf8")
         yield test_file

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -64,3 +65,8 @@ def testfile(
         test_file = tmp_dir / name
         test_file.write_text(content, encoding="utf8")
         yield test_file
+
+
+def unload_module(name: str) -> None:
+    if name in sys.modules:
+        del sys.modules[name]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -124,6 +124,31 @@ def testfile(
         yield test_file
 
 
+@contextmanager
+def temp_python_module(
+    content: str, *, name="foo"
+) -> Generator[Path, None, None]:
+    """
+    A Context Manager to create a new Python module in a temporary directory.
+    The temporary directory will be added to the module search path and removed
+    from the search path when the context is exited. Also it is ensured that
+    the module is unloaded if the context is exited.
+
+    Args:
+        content: Python code to write into the temporary module.
+        name: Name of the new Python module. By default: "foo".
+
+    Example:
+        with temp_python_module("print()", name="bar") as python_module_path
+    """
+    with tempdir(
+        add_to_sys_path=True,
+    ) as tmp_dir, ensure_unload_module(name):
+        test_file = tmp_dir / f"{name}.py"
+        test_file.write_text(content, encoding="utf8")
+        yield test_file
+
+
 def unload_module(name: str) -> None:
     """
     Unload a Python module

--- a/tests/cli/test_check.py
+++ b/tests/cli/test_check.py
@@ -17,6 +17,7 @@
 
 import sys
 import unittest
+from argparse import Namespace
 from unittest.mock import MagicMock, call
 
 from autohooks.cli.check import check_config, check_hooks, check_pre_commit_hook
@@ -31,9 +32,10 @@ from tests import tempgitdir
 class CheckCliTestCase(unittest.TestCase):
     def test_no_pre_commit_hooks_no_pyproject_toml(self):
         term = MagicMock()
+        args = Namespace()
 
         with tempgitdir() as tmpdir:
-            check_hooks(term)
+            check_hooks(term, args)
 
         term.ok.assert_not_called()
         term.warning.assert_not_called()
@@ -55,12 +57,13 @@ class CheckCliTestCase(unittest.TestCase):
 
     def test_no_pre_commit_hooks_no_autohooks_settings(self):
         term = MagicMock()
+        args = Namespace()
 
         with tempgitdir() as tmpdir:
             pyproject_toml = tmpdir / "pyproject.toml"
             pyproject_toml.touch()
 
-            check_hooks(term)
+            check_hooks(term, args)
 
         term.ok.assert_not_called()
         term.warning.assert_not_called()
@@ -81,6 +84,7 @@ class CheckCliTestCase(unittest.TestCase):
 
     def test_all_checks_success(self):
         term = MagicMock()
+        args = Namespace()
 
         with tempgitdir() as tmpdir:
             pyproject_toml = tmpdir / "pyproject.toml"
@@ -104,7 +108,7 @@ def precommit(*args):
                 encoding="utf8",
             )
 
-            check_hooks(term)
+            check_hooks(term, args)
 
         self.assertEqual(term.ok.call_count, 3)
         term.ok.assert_has_calls(

--- a/tests/cli/test_plugins.py
+++ b/tests/cli/test_plugins.py
@@ -1,0 +1,240 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from argparse import Namespace
+from unittest.mock import MagicMock, call
+
+from autohooks.cli.plugins import add_plugins, list_plugins, remove_plugins
+from tests import temp_file, tempdir, unload_module
+
+
+class AddPluginsCliTestCase(unittest.TestCase):
+    def test_add_plugin(self):
+        term = MagicMock()
+        args = Namespace(name=["foo", "bar"])
+
+        expected = """[tool.autohooks]
+mode = "pythonpath"
+pre-commit = ["bar", "foo"]
+"""
+
+        with tempdir(change_into=True) as tmp_dir:
+            add_plugins(term, args)
+
+            term.warning.assert_not_called()
+            term.info.assert_has_calls([call("Added plugins:")])
+            term.ok.assert_has_calls([call('"bar"'), call('"foo"')])
+
+            pyproject_toml = tmp_dir / "pyproject.toml"
+            content = pyproject_toml.read_text(encoding="utf8")
+
+            self.assertEqual(content, expected)
+
+    def test_add_plugin_with_existing(self):
+        term = MagicMock()
+        args = Namespace(name=["foo"])
+        existing = """[tool.autohooks]
+mode = "poetry"
+pre-commit = ["bar"]
+"""
+
+        expected = """[tool.autohooks]
+mode = "poetry"
+pre-commit = ["bar", "foo"]
+"""
+
+        with temp_file(
+            existing, name="pyproject.toml", change_into=True
+        ) as pyproject_toml:
+            add_plugins(term, args)
+
+            term.warning.assert_not_called()
+            term.info.assert_has_calls(
+                [call("Added plugins:"), call("Currently used plugins:")]
+            )
+            term.ok.assert_has_calls([call('"foo"')])
+
+            content = pyproject_toml.read_text(encoding="utf8")
+
+            self.assertEqual(content, expected)
+
+    def test_add_duplicate_plugin(self):
+        term = MagicMock()
+        args = Namespace(name=["foo", "bar"])
+        existing = """[tool.autohooks]
+mode = "poetry"
+pre-commit = ["bar"]
+"""
+
+        expected = """[tool.autohooks]
+mode = "poetry"
+pre-commit = ["bar", "foo"]
+"""
+
+        with temp_file(
+            existing, name="pyproject.toml", change_into=True
+        ) as pyproject_toml:
+            add_plugins(term, args)
+
+            term.warning.assert_has_calls([call('"bar"')])
+            term.info.assert_has_calls(
+                [
+                    call("Skipped already used plugins:"),
+                    call("Added plugins:"),
+                    call("Currently used plugins:"),
+                ]
+            )
+            term.ok.assert_has_calls([call('"foo"')])
+
+            content = pyproject_toml.read_text(encoding="utf8")
+
+            self.assertEqual(content, expected)
+
+
+class ListPluginsCliTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        unload_module("bar")
+        return super().setUp()
+
+    def test_invalid_plugins(self):
+        term = MagicMock()
+        args = Namespace()
+
+        existing = """[tool.autohooks]
+mode = "poetry"
+pre-commit = ["bar"]
+"""
+        with temp_file(existing, name="pyproject.toml", change_into=True):
+            list_plugins(term, args)
+
+            term.warning.assert_not_called()
+            term.info.assert_has_calls(
+                [
+                    call("Currently used plugins:"),
+                ]
+            )
+            term.ok.assert_not_called()
+            term.error.assert_called_once_with(
+                '"bar": "bar" is not a valid autohooks plugin. No module '
+                "named 'bar'"
+            )
+
+    def test_existing_plugins(self):
+        term = MagicMock()
+        args = Namespace()
+
+        pyproject_toml_content = """[tool.autohooks]
+mode = "poetry"
+pre-commit = ["bar"]
+"""
+
+        plugin_content = """
+def precommit(config=None, **kwargs):
+    pass
+"""
+        with tempdir(change_into=True, add_to_sys_path=True) as tmp_dir:
+            pyproject_toml = tmp_dir / "pyproject.toml"
+            pyproject_toml.write_text(pyproject_toml_content, encoding="utf8")
+
+            bar_plugin = tmp_dir / "bar.py"
+            bar_plugin.write_text(plugin_content, encoding="utf8")
+
+            list_plugins(term, args)
+
+            term.warning.assert_not_called()
+            term.info.assert_has_calls(
+                [
+                    call("Currently used plugins:"),
+                ]
+            )
+            term.error.assert_not_called()
+            term.ok.assert_called_once_with('"bar"')
+
+
+class RemovePluginsCliTestCase(unittest.TestCase):
+    def test_remove_plugins(self):
+        term = MagicMock()
+        args = Namespace(name=["foo", "bar"])
+
+        existing = """[tool.autohooks]
+mode = "pythonpath"
+pre-commit = ["bar", "foo"]
+"""
+        expected = """[tool.autohooks]
+mode = "pythonpath"
+pre-commit = []
+"""
+
+        with temp_file(
+            existing, name="pyproject.toml", change_into=True
+        ) as pyproject_toml:
+            remove_plugins(term, args)
+
+            term.warning.assert_not_called()
+            term.info.assert_has_calls([call("Removed plugins:")])
+            term.ok.assert_has_calls([call('"bar"'), call('"foo"')])
+
+            content = pyproject_toml.read_text(encoding="utf8")
+
+            self.assertEqual(content, expected)
+
+    def test_no_config(self):
+        term = MagicMock()
+        args = Namespace(name=["foo", "bar"])
+
+        with tempdir(change_into=True) as temp_dir:
+            remove_plugins(term, args)
+
+            term.warning.assert_called_once_with("No plugins to remove.")
+            term.info.assert_not_called()
+            term.ok.assert_not_called()
+
+            pyproject_toml = temp_dir / "pyproject.toml"
+            self.assertFalse(pyproject_toml.exists())
+
+    def test_remove_plugins_skipped(self):
+        term = MagicMock()
+        args = Namespace(name=["foo", "bar"])
+
+        existing = """[tool.autohooks]
+mode = "pythonpath"
+pre-commit = ["foo"]
+"""
+        expected = """[tool.autohooks]
+mode = "pythonpath"
+pre-commit = []
+"""
+
+        with temp_file(
+            existing, name="pyproject.toml", change_into=True
+        ) as pyproject_toml:
+            remove_plugins(term, args)
+
+            term.warning.assert_called_once_with('"bar"')
+            term.info.assert_has_calls(
+                [
+                    call("Skipped not used plugins:"),
+                    call("Removed plugins:"),
+                    call("Currently used plugins:"),
+                ]
+            )
+            term.ok.assert_has_calls([call('"foo"')])
+
+            content = pyproject_toml.read_text(encoding="utf8")
+
+            self.assertEqual(content, expected)

--- a/tests/precommit/__init__.py
+++ b/tests/precommit/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/precommit/test_run.py
+++ b/tests/precommit/test_run.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from autohooks.precommit.run import (
+    CheckPluginError,
+    CheckPluginWarning,
+    check_plugin,
+)
+from tests import temp_python_module, tempdir
+
+
+class CheckPluginTestCase(unittest.TestCase):
+    def test_plugin_not_found(self):
+        with tempdir(change_into=True):
+            result = check_plugin("foo.bar")
+
+            self.assertIsInstance(result, CheckPluginError)
+            self.assertIn(
+                '"foo.bar" is not a valid autohooks plugin.', result.message
+            )
+
+    def test_no_precommit_function(self):
+        content = """print()"""
+        with temp_python_module(
+            content,
+            name="foo",
+        ):
+            result = check_plugin("foo")
+
+            self.assertIsInstance(result, CheckPluginError)
+            self.assertEqual(
+                result.message,
+                'Plugin "foo" has no precommit function. The function is '
+                "required to run the plugin as git pre commit hook.",
+            )
+
+    def test_no_precommit_function_arguments(self):
+        content = """def precommit():
+  print()"""
+        with temp_python_module(
+            content,
+            name="foo",
+        ):
+            result = check_plugin("foo")
+
+            self.assertIsInstance(result, CheckPluginWarning)
+            self.assertEqual(
+                'Plugin "foo" uses a deprecated signature for its precommit '
+                "function. It is missing the **kwargs parameter.",
+                result.message,
+            )
+
+    def test_success(self):
+        content = """def precommit(**kwargs):
+  print()"""
+        with temp_python_module(
+            content,
+            name="foo",
+        ):
+            self.assertIsNone(check_plugin("foo"))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -20,7 +20,7 @@
 import unittest
 
 from autohooks.settings import AutohooksSettings, Mode
-from tests import tempdir, testfile
+from tests import temp_file, tempdir
 
 
 class ModeTestCase(unittest.TestCase):
@@ -130,7 +130,7 @@ plugins.foo.lorem = 'dolor'
 [tool.autohooks.plugins.bar]
 foo = 'bar'
 """
-        with testfile(pyproject_toml_1) as toml:
+        with temp_file(pyproject_toml_1) as toml:
             settings.write(toml)
 
             self.assertEqual(settings.mode, Mode.UNDEFINED)
@@ -150,7 +150,7 @@ plugins.foo.lorem = 'dolor'
 [tool.autohooks.plugins.bar]
 foo = 'bar'
 """
-        with testfile(pyproject_toml_1) as toml:
+        with temp_file(pyproject_toml_1) as toml:
             settings.write(toml)
 
             self.assertEqual(settings.mode, Mode.POETRY)


### PR DESCRIPTION
**What**:

Add a new CLI for adding, removing and listing autohooks plugins

**Why**:

Make plugin handling easier. Currently the plugins need to be changed by editing the pyproject.toml file manually. This requires users to know TOML.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] PR merge commit message adjusted
- [x] Documentation
