### PR TITLE
adopt windows platform

### DIFF
--- a/autohooks/template.py
+++ b/autohooks/template.py
@@ -23,7 +23,7 @@ from autohooks.utils import get_autohooks_directory_path
 
 PYTHON3_SHEBANG = "/usr/bin/env python3"
 PIPENV_SHEBANG = "/usr/bin/env -S pipenv run python3"
-POETRY_SHEBANG = "/usr/bin/env -S poetry run python3"
+POETRY_SHEBANG = "/usr/bin/env -S poetry run python"
 # For OS's that don't support '/usr/bin/env -S'.
 PIPENV_MULTILINE_SHEBANG = (
     "/bin/sh\n"
@@ -35,7 +35,7 @@ PIPENV_MULTILINE_SHEBANG = (
 POETRY_MULTILINE_SHEBANG = (
     "/bin/sh\n"
     "\"true\" ''':'\n"
-    'poetry run python3 "$0" "$@"\n'
+    'poetry run python "$0" "$@"\n'
     'exit "$?"\n'
     "'''"
 )

--- a/autohooks/utils.py
+++ b/autohooks/utils.py
@@ -129,7 +129,7 @@ def is_split_env():
             check=True,
         )
         is_split = True
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         is_split = False
 
     return is_split

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -69,7 +69,7 @@ class PreCommitTemplateTestCase(unittest.TestCase):
         template = PreCommitTemplate(path)
         self.assertEqual(
             template.render(mode=Mode.POETRY),
-            "/usr/bin/env -S poetry run python3",
+            "/usr/bin/env -S poetry run python",
         )
 
     def test_should_render_mode_pipenv_multiline(self):
@@ -94,7 +94,7 @@ class PreCommitTemplateTestCase(unittest.TestCase):
             (
                 "/bin/sh\n"
                 "\"true\" ''':'\n"
-                'poetry run python3 "$0" "$@"\n'
+                'poetry run python "$0" "$@"\n'
                 'exit "$?"\n'
                 "'''"
             ),


### PR DESCRIPTION
**What**:
Add windows platform support

**Why**:

Windows platform doesn't work.

**How**:

1. Fix an issue where is_split_env method is not runable on windows platform hence FileNotFoundError exception stops autohooks activite process.
2. pre-commit shebang changed. When setup a virtualenv by using poetry, python3 alias doesn't install on windows. Due to python 2 is deprecated, it is safe to use python in shebang instead of python3.

**Checklist**:

- [x] Tests
- [x] PR merge commit message adjusted
- [ ] Documentation
