### PR TITLE
Fix : Fix an issue where is_split_env method is not runable on windows

### DIFF
--- a/autohooks/utils.py
+++ b/autohooks/utils.py
@@ -129,7 +129,7 @@ def is_split_env():
             check=True,
         )
         is_split = True
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         is_split = False
 
     return is_split


### PR DESCRIPTION
**What**:
Fix an issue where is_split_env method is not runnable on windows

**Why**:
Shell script running in subprocess is not runnable on windows.

**How**:

Catch FileNotFoundError during split env checking.

**Checklist**:

- [x] Tests
- [x] PR merge commit message adjusted
- [ ] Documentation
