### PR TITLE
Fix: Change pre-commit shebang line when using poetry

### DIFF
--- a/autohooks/template.py
+++ b/autohooks/template.py
@@ -23,7 +23,7 @@ from autohooks.utils import get_autohooks_directory_path
 
 PYTHON3_SHEBANG = "/usr/bin/env python3"
 PIPENV_SHEBANG = "/usr/bin/env -S pipenv run python3"
-POETRY_SHEBANG = "/usr/bin/env -S poetry run python3"
+POETRY_SHEBANG = "/usr/bin/env -S poetry run python"
 # For OS's that don't support '/usr/bin/env -S'.
 PIPENV_MULTILINE_SHEBANG = (
     "/bin/sh\n"
@@ -35,7 +35,7 @@ PIPENV_MULTILINE_SHEBANG = (
 POETRY_MULTILINE_SHEBANG = (
     "/bin/sh\n"
     "\"true\" ''':'\n"
-    'poetry run python3 "$0" "$@"\n'
+    'poetry run python "$0" "$@"\n'
     'exit "$?"\n'
     "'''"
 )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -69,7 +69,7 @@ class PreCommitTemplateTestCase(unittest.TestCase):
         template = PreCommitTemplate(path)
         self.assertEqual(
             template.render(mode=Mode.POETRY),
-            "/usr/bin/env -S poetry run python3",
+            "/usr/bin/env -S poetry run python",
         )
 
     def test_should_render_mode_pipenv_multiline(self):
@@ -94,7 +94,7 @@ class PreCommitTemplateTestCase(unittest.TestCase):
             (
                 "/bin/sh\n"
                 "\"true\" ''':'\n"
-                'poetry run python3 "$0" "$@"\n'
+                'poetry run python "$0" "$@"\n'
                 'exit "$?"\n'
                 "'''"
             ),


### PR DESCRIPTION
**What**:
Fix: Change pre-commit shebang line when using poetry

**Why**:
pre-commit not able to run on windows due to poetry doesn't create python3 alias in virtualenv.

**How**:

Change shebang from ``poetry run python3`` to ``poetry run python`` when using poetry mode.

**Checklist**:

- [x] Tests
- [x] PR merge commit message adjusted
- [ ] Documentation
