### PR TITLE
Fix: Change out terminal function to not apply formatting and escaping

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -17,7 +17,6 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/autohooks/terminal.py
+++ b/autohooks/terminal.py
@@ -106,7 +106,7 @@ def out(message: str):
     Args:
         message: Message to print
     """
-    __term.print(message)
+    __term.out(message)
 
 
 def overwrite(message: str, new_line: bool = False):

--- a/tests/api/test_terminal.py
+++ b/tests/api/test_terminal.py
@@ -45,7 +45,7 @@ class TerminalOutputApiTestCase(unittest.TestCase):
 
     def test_out(self):
         out("foo bar")
-        self.term.print.assert_called_with("foo bar")
+        self.term.out.assert_called_with("foo bar")
 
     def test_warning(self):
         warning("foo bar")


### PR DESCRIPTION
**What**:

Change out terminal function to not apply formatting and escaping

This fixes the output of errors created by pylint which include ANSI color escapes. With this fix these output is displayed correctly again.

**Why**:

Fix pylint output.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] PR merge commit message adjusted
- [ ] Documentation
