### PR TITLE
Fix: Linting in CI via ruff check

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -19,7 +19,7 @@ jobs:
     uses: greenbone/workflows/.github/workflows/ci-python.yml@main
     with:
       lint-packages: autohooks tests
-      linter: ruff
+      linter: ruff check
       python-version: ${{ matrix.python-version }}
 
   codecov:


### PR DESCRIPTION
## What

Fix: Linting in CI via ruff check

## Why

`ruff` is deprecated. ...


